### PR TITLE
fixes header div 

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,9 @@
 p{
   width: 60%;
 }
+.header__title{
+  top:35%;
+}
 
 @media (max-width: 600px) {
   .menu__desktop {
@@ -18,6 +21,10 @@ p{
   }
   p{
     width: 80%;
+  }
+  .header__title{
+    top:10%;
+    font-size: 3vw;
   }
 }
 
@@ -58,6 +65,7 @@ p{
   transform: translate3d(-200px, 0, 0);
   transition: transform 0.35s;
       z-index: 1;
+
 }
 
 .menu__mobile__toggle {
@@ -158,7 +166,7 @@ label{
 }
 .header__title{
   position: absolute;
-  top: 50%;
+
 left: 11%;
 right: 11%;
 


### PR DESCRIPTION
referencing  Title overlaying content on mobile. #23
fixed header title by changing font size to vw (viewport width) :+1:  :+1:  :+1:  :+1:  :+1:  :+1:  :+1: 

this is probably my favourite thing I learned